### PR TITLE
Update ghostwriter/shell to version 0.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/json": "^3.0.1",
         "ghostwriter/option": "^2.0.0",
         "ghostwriter/result": "^2.0.0",
-        "ghostwriter/shell": "^0.1.3",
+        "ghostwriter/shell": "^0.1.4",
         "ghostwriter/uuid": "^1.0.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0dfa30b5a4b3bf058d892bcdf969960d",
+    "content-hash": "205ee6498999334b22f79fb86e48e3ee",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -663,16 +663,16 @@
         },
         {
             "name": "ghostwriter/shell",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/shell.git",
-                "reference": "d39f27908bb1bcf4512e7faa6064ad87bdd986da"
+                "reference": "52baa393e18d9db93f479c96241d6d644ec07f10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/d39f27908bb1bcf4512e7faa6064ad87bdd986da",
-                "reference": "d39f27908bb1bcf4512e7faa6064ad87bdd986da",
+                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/52baa393e18d9db93f479c96241d6d644ec07f10",
+                "reference": "52baa393e18d9db93f479c96241d6d644ec07f10",
                 "shasum": ""
             },
             "require": {
@@ -734,7 +734,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-25T16:03:59+00:00"
+            "time": "2026-01-25T16:15:33+00:00"
         },
         {
             "name": "ghostwriter/uuid",


### PR DESCRIPTION
Updates the `ghostwriter/shell` dependency from `0.1.3` to `0.1.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`